### PR TITLE
Init refactor

### DIFF
--- a/packages/serum-remote/src/dexes/dex.ts
+++ b/packages/serum-remote/src/dexes/dex.ts
@@ -12,7 +12,7 @@ import { LIQUIDITY_STATE_LAYOUT_V4 } from "@raydium-io/raydium-sdk";
  * @param connection
  * @param marketIds
  */
-export const getInitLegAccounts = async (
+export const getTradeAccounts = async (
   connection: web3.Connection,
   cluster: SolCluster,
   marketIds: web3.PublicKey[],
@@ -44,14 +44,9 @@ export const getInitLegAccounts = async (
             {},
             openBookProgramId
           );
-          legAccounts = OpenBookDex.initLegAccounts(
-            programId,
-            serumMarket,
-            strategyKey,
-            tradeSourceAccount,
-            tradeDestinationAccount,
-            destinationMint
-          );
+          // TODO: Handle creating trade accounts (note OpenOrders account and owner will have
+          //  to be checked or created)
+
           legAdditionalData = new BN(
             // @ts-ignore
             serumMarket._baseSplTokenDecimals
@@ -77,17 +72,8 @@ export const getInitLegAccounts = async (
             {},
             raydiumV4MarketInfo.marketProgramId
           );
-          legAccounts = Raydium.initLegAccounts(
-            raydiumV4MarketInfo.baseMint,
-            raydiumV4MarketInfo.baseDecimal.toNumber(),
-            raydiumV4MarketInfo.quoteMint,
-            raydiumV4MarketInfo.quoteDecimal.toNumber(),
-            market,
-            strategyKey,
-            tradeSourceAccount,
-            tradeDestinationAccount,
-            destinationMint
-          );
+          // TODO: Handle creating trade accounts
+
           legAdditionalData = Buffer.from([]);
           break;
         }

--- a/packages/serum-remote/src/dexes/openBookDex.ts
+++ b/packages/serum-remote/src/dexes/openBookDex.ts
@@ -99,17 +99,13 @@ export default class OpenBookDex {
   }
 
   static async tradeAccounts(
-    remoteProgramId: web3.PublicKey,
     serumMarket: Market,
-    strategyKey: web3.PublicKey,
     collateralAccount: web3.PublicKey,
     tradeDestinationAccount: web3.PublicKey,
-    destinationMint: web3.PublicKey
+    destinationMint: web3.PublicKey,
+    openOrdersKey: web3.PublicKey,
+    openOrdersOwner: web3.PublicKey
   ): Promise<web3.AccountMeta[]> {
-    const openOrdersKey = (
-      await this.deriveOpenOrders(remoteProgramId, strategyKey)
-    )[0];
-
     const vaultSigner = await this.deriveVaultSigner(serumMarket);
     return [
       { pubkey: serumMarket.programId, isWritable: false, isSigner: false },
@@ -147,7 +143,7 @@ export default class OpenBookDex {
       // This is the SRM referral account
       // TODO: Maybe actually implement this?
       { pubkey: web3.SYSVAR_RENT_PUBKEY, isWritable: false, isSigner: false },
-      { pubkey: strategyKey, isWritable: false, isSigner: false },
+      { pubkey: openOrdersOwner, isWritable: false, isSigner: false },
       { pubkey: collateralAccount, isWritable: false, isSigner: false },
       { pubkey: tradeDestinationAccount, isWritable: true, isSigner: false },
       { pubkey: destinationMint, isWritable: false, isSigner: false },

--- a/packages/serum-remote/src/dexes/openBookDex.ts
+++ b/packages/serum-remote/src/dexes/openBookDex.ts
@@ -18,17 +18,6 @@ export default class OpenBookDex {
     }
   }
 
-  static deriveOpenOrders(
-    remoteProgramId: web3.PublicKey,
-    strategyKey: web3.PublicKey
-  ): [web3.PublicKey, number] {
-    const encoded = new TextEncoder().encode("openOrders");
-    return web3.PublicKey.findProgramAddressSync(
-      [strategyKey.toBuffer(), encoded],
-      remoteProgramId
-    );
-  }
-
   static deriveVaultSigner(serumMarket: Market): web3.PublicKey {
     // @ts-ignore
     const nonce = serumMarket._decoded.vaultSignerNonce as BN;
@@ -40,69 +29,10 @@ export default class OpenBookDex {
     );
   }
 
-  static initLegAccounts(
-    remoteProgramId: web3.PublicKey,
-    serumMarket: Market,
-    strategyKey: web3.PublicKey,
-    tradeSourceAccount: web3.PublicKey,
-    tradeDestinationAccount: web3.PublicKey,
-    destinationMint: web3.PublicKey
-  ): web3.AccountMeta[] {
-    const openOrdersKey = this.deriveOpenOrders(
-      remoteProgramId,
-      strategyKey
-    )[0];
-
-    const vaultSigner = this.deriveVaultSigner(serumMarket);
-    return [
-      { pubkey: serumMarket.programId, isWritable: false, isSigner: false },
-      { pubkey: serumMarket.address, isWritable: false, isSigner: false },
-      { pubkey: serumMarket.bidsAddress, isWritable: false, isSigner: false },
-      { pubkey: serumMarket.asksAddress, isWritable: false, isSigner: false },
-      { pubkey: openOrdersKey, isWritable: true, isSigner: false },
-      {
-        // @ts-ignore
-        pubkey: serumMarket._decoded.requestQueue,
-        isWritable: false,
-        isSigner: false,
-      },
-      {
-        // @ts-ignore
-        pubkey: serumMarket._decoded.eventQueue,
-        isWritable: false,
-        isSigner: false,
-      },
-      {
-        // @ts-ignore
-        pubkey: serumMarket._decoded.baseVault,
-        isWritable: false,
-        isSigner: false,
-      },
-      {
-        // @ts-ignore
-        pubkey: serumMarket._decoded.quoteVault,
-        isWritable: false,
-        isSigner: false,
-      },
-      { pubkey: vaultSigner, isWritable: false, isSigner: false },
-      { pubkey: TOKEN_PROGRAM_ID, isWritable: false, isSigner: false },
-      { pubkey: web3.SYSVAR_RENT_PUBKEY, isWritable: false, isSigner: false },
-      // This is the SRM referral account
-      // TODO: Maybe actually implement this?
-      { pubkey: web3.SYSVAR_RENT_PUBKEY, isWritable: false, isSigner: false },
-      { pubkey: strategyKey, isWritable: false, isSigner: false },
-      { pubkey: tradeSourceAccount, isWritable: false, isSigner: false },
-      // If this is not the final Leg in a Route, than it must be writable.
-      { pubkey: tradeDestinationAccount, isWritable: true, isSigner: false },
-      { pubkey: destinationMint, isWritable: false, isSigner: false },
-    ];
-  }
-
   static async tradeAccounts(
     serumMarket: Market,
     collateralAccount: web3.PublicKey,
     tradeDestinationAccount: web3.PublicKey,
-    destinationMint: web3.PublicKey,
     openOrdersKey: web3.PublicKey,
     openOrdersOwner: web3.PublicKey
   ): Promise<web3.AccountMeta[]> {
@@ -146,62 +76,6 @@ export default class OpenBookDex {
       { pubkey: openOrdersOwner, isWritable: false, isSigner: false },
       { pubkey: collateralAccount, isWritable: false, isSigner: false },
       { pubkey: tradeDestinationAccount, isWritable: true, isSigner: false },
-      { pubkey: destinationMint, isWritable: false, isSigner: false },
-    ];
-  }
-
-  static async reclaimAccounts(
-    remoteProgramId: web3.PublicKey,
-    serumMarket: Market,
-    strategyKey: web3.PublicKey,
-    collateralAccount: web3.PublicKey,
-    destinationAccount: web3.PublicKey,
-    destinationMint: web3.PublicKey
-  ): Promise<web3.AccountMeta[]> {
-    const [[openOrdersKey], vaultSigner] = await Promise.all([
-      this.deriveOpenOrders(remoteProgramId, strategyKey),
-      this.deriveVaultSigner(serumMarket),
-    ]);
-    return [
-      { pubkey: serumMarket.programId, isWritable: false, isSigner: false },
-      { pubkey: serumMarket.address, isWritable: false, isSigner: false },
-      { pubkey: serumMarket.bidsAddress, isWritable: false, isSigner: false },
-      { pubkey: serumMarket.asksAddress, isWritable: false, isSigner: false },
-      { pubkey: openOrdersKey, isWritable: true, isSigner: false },
-      {
-        // @ts-ignore
-        pubkey: serumMarket._decoded.requestQueue,
-        isWritable: false,
-        isSigner: false,
-      },
-      {
-        // @ts-ignore
-        pubkey: serumMarket._decoded.eventQueue,
-        isWritable: false,
-        isSigner: false,
-      },
-      {
-        // @ts-ignore
-        pubkey: serumMarket._decoded.baseVault,
-        isWritable: false,
-        isSigner: false,
-      },
-      {
-        // @ts-ignore
-        pubkey: serumMarket._decoded.quoteVault,
-        isWritable: false,
-        isSigner: false,
-      },
-      { pubkey: vaultSigner, isWritable: false, isSigner: false },
-      { pubkey: TOKEN_PROGRAM_ID, isWritable: false, isSigner: false },
-      { pubkey: web3.SYSVAR_RENT_PUBKEY, isWritable: false, isSigner: false },
-      // This is the SRM referral account
-      // TODO: Maybe actually implement this?
-      { pubkey: web3.SYSVAR_RENT_PUBKEY, isWritable: false, isSigner: false },
-      { pubkey: strategyKey, isWritable: false, isSigner: false },
-      { pubkey: collateralAccount, isWritable: true, isSigner: false },
-      { pubkey: destinationAccount, isWritable: false, isSigner: false },
-      { pubkey: destinationMint, isWritable: false, isSigner: false },
     ];
   }
 }

--- a/packages/serum-remote/src/dexes/raydium.ts
+++ b/packages/serum-remote/src/dexes/raydium.ts
@@ -31,106 +31,6 @@ export default class Raydium {
     }
   }
 
-  static initLegAccounts(
-    baseMint: web3.PublicKey,
-    baseDecimals: number,
-    quoteMint: web3.PublicKey,
-    quoteDecimals: number,
-    serumMarket: Market,
-    strategyKey: web3.PublicKey,
-    tradeSourceAccount: web3.PublicKey,
-    tradeDestinationAccount: web3.PublicKey,
-    destinationMint: web3.PublicKey
-  ): web3.AccountMeta[] {
-    // find associated poolKeys for market
-    const liquidityVersion =
-      LIQUIDITY_PROGRAMID_TO_VERSION[this.V4_PROGRAM_ID.toString()];
-    const associatedPoolKeys = Liquidity.getAssociatedPoolKeys({
-      version: liquidityVersion,
-      marketVersion: LIQUIDITY_VERSION_TO_SERUM_VERSION[liquidityVersion],
-      baseMint,
-      quoteMint,
-      baseDecimals,
-      quoteDecimals,
-      marketId: serumMarket.address,
-      programId: this.V4_PROGRAM_ID,
-      marketProgramId: serumMarket.programId,
-    });
-
-    const vaultSigner = OpenBookDex.deriveVaultSigner(serumMarket);
-
-    return [
-      { pubkey: this.V4_PROGRAM_ID, isWritable: false, isSigner: false },
-      { pubkey: associatedPoolKeys.id, isWritable: false, isSigner: false },
-      {
-        pubkey: associatedPoolKeys.authority,
-        isWritable: false,
-        isSigner: false,
-      },
-      {
-        pubkey: associatedPoolKeys.openOrders,
-        isWritable: false,
-        isSigner: false,
-      },
-      {
-        pubkey: associatedPoolKeys.targetOrders,
-        isWritable: false,
-        isSigner: false,
-      },
-      {
-        pubkey: associatedPoolKeys.baseVault,
-        isWritable: false,
-        isSigner: false,
-      },
-      {
-        pubkey: associatedPoolKeys.quoteVault,
-        isWritable: false,
-        isSigner: false,
-      },
-      {
-        pubkey: associatedPoolKeys.marketProgramId,
-        isWritable: false,
-        isSigner: false,
-      },
-      {
-        pubkey: associatedPoolKeys.marketId,
-        isWritable: false,
-        isSigner: false,
-      },
-      {
-        pubkey: serumMarket.bidsAddress,
-        isWritable: false,
-        isSigner: false,
-      },
-      { pubkey: serumMarket.asksAddress, isWritable: false, isSigner: false },
-      {
-        // @ts-ignore
-        pubkey: serumMarket._decoded.eventQueue,
-        isWritable: false,
-        isSigner: false,
-      },
-      {
-        // @ts-ignore
-        pubkey: serumMarket._decoded.baseVault,
-        isWritable: false,
-        isSigner: false,
-      },
-      {
-        // @ts-ignore
-        pubkey: serumMarket._decoded.quoteVault,
-        isWritable: false,
-        isSigner: false,
-      },
-      { pubkey: vaultSigner, isWritable: false, isSigner: false },
-      { pubkey: tradeSourceAccount, isWritable: false, isSigner: false },
-      // If this is not the final Leg in a Route, than it must be writable.
-      { pubkey: tradeDestinationAccount, isWritable: true, isSigner: false },
-      { pubkey: strategyKey, isWritable: false, isSigner: false },
-      { pubkey: TOKEN_PROGRAM_ID, isWritable: false, isSigner: false },
-      { pubkey: destinationMint, isWritable: false, isSigner: false },
-    ];
-  }
-
   static tradeAccounts(
     baseMint: web3.PublicKey,
     baseDecimals: number,
@@ -139,8 +39,7 @@ export default class Raydium {
     serumMarket: Market,
     tradeSourceAccount: web3.PublicKey,
     tradeSourceOwner: web3.PublicKey,
-    tradeDestinationAccount: web3.PublicKey,
-    destinationMint: web3.PublicKey
+    tradeDestinationAccount: web3.PublicKey
   ): web3.AccountMeta[] {
     // find associated poolKeys for market
     const liquidityVersion =
@@ -227,7 +126,6 @@ export default class Raydium {
       { pubkey: tradeDestinationAccount, isWritable: true, isSigner: false },
       { pubkey: tradeSourceOwner, isWritable: false, isSigner: false },
       { pubkey: TOKEN_PROGRAM_ID, isWritable: false, isSigner: false },
-      { pubkey: destinationMint, isWritable: false, isSigner: false },
     ];
   }
 }

--- a/packages/serum-remote/src/dexes/raydium.ts
+++ b/packages/serum-remote/src/dexes/raydium.ts
@@ -137,8 +137,8 @@ export default class Raydium {
     quoteMint: web3.PublicKey,
     quoteDecimals: number,
     serumMarket: Market,
-    strategyKey: web3.PublicKey,
     tradeSourceAccount: web3.PublicKey,
+    tradeSourceOwner: web3.PublicKey,
     tradeDestinationAccount: web3.PublicKey,
     destinationMint: web3.PublicKey
   ): web3.AccountMeta[] {
@@ -225,7 +225,7 @@ export default class Raydium {
       { pubkey: tradeSourceAccount, isWritable: true, isSigner: false },
       // If this is not the final Leg in a Route, than it must be writable.
       { pubkey: tradeDestinationAccount, isWritable: true, isSigner: false },
-      { pubkey: strategyKey, isWritable: false, isSigner: false },
+      { pubkey: tradeSourceOwner, isWritable: false, isSigner: false },
       { pubkey: TOKEN_PROGRAM_ID, isWritable: false, isSigner: false },
       { pubkey: destinationMint, isWritable: false, isSigner: false },
     ];

--- a/packages/serum-remote/src/serum_remote.ts
+++ b/packages/serum-remote/src/serum_remote.ts
@@ -516,14 +516,6 @@ export type SerumRemote = {
           ]
         },
         {
-          "name": "lookupTable",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "The look up table address."
-          ]
-        },
-        {
           "name": "tokenProgram",
           "isMut": false,
           "isSigner": false
@@ -550,10 +542,6 @@ export type SerumRemote = {
         {
           "name": "reclaimDate",
           "type": "i64"
-        },
-        {
-          "name": "additionalData",
-          "type": "bytes"
         }
       ]
     },
@@ -1588,14 +1576,6 @@ export const IDL: SerumRemote = {
           ]
         },
         {
-          "name": "lookupTable",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "The look up table address."
-          ]
-        },
-        {
           "name": "tokenProgram",
           "isMut": false,
           "isSigner": false
@@ -1622,10 +1602,6 @@ export const IDL: SerumRemote = {
         {
           "name": "reclaimDate",
           "type": "i64"
-        },
-        {
-          "name": "additionalData",
-          "type": "bytes"
         }
       ]
     },

--- a/packages/serum-remote/src/serum_remote.ts
+++ b/packages/serum-remote/src/serum_remote.ts
@@ -693,35 +693,6 @@ export type SerumRemote = {
               "The bump for the strategy's derived address"
             ],
             "type": "u8"
-          },
-          {
-            "name": "lookupTable",
-            "docs": [
-              "The address of the look up table. This needs to be stored on-chain for keeping clients",
-              "in sync"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "accountList",
-            "type": {
-              "array": [
-                "publicKey",
-                32
-              ]
-            }
-          },
-          {
-            "name": "additionalData",
-            "docs": [
-              "A slice that holds additional data for DEXes in the route"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                32
-              ]
-            }
           }
         ]
       }
@@ -1763,35 +1734,6 @@ export const IDL: SerumRemote = {
               "The bump for the strategy's derived address"
             ],
             "type": "u8"
-          },
-          {
-            "name": "lookupTable",
-            "docs": [
-              "The address of the look up table. This needs to be stored on-chain for keeping clients",
-              "in sync"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "accountList",
-            "type": {
-              "array": [
-                "publicKey",
-                32
-              ]
-            }
-          },
-          {
-            "name": "additionalData",
-            "docs": [
-              "A slice that holds additional data for DEXes in the route"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                32
-              ]
-            }
           }
         ]
       }

--- a/packages/serum-remote/src/serum_remote.ts
+++ b/packages/serum-remote/src/serum_remote.ts
@@ -575,7 +575,12 @@ export type SerumRemote = {
           "isSigner": false
         }
       ],
-      "args": []
+      "args": [
+        {
+          "name": "additionalData",
+          "type": "bytes"
+        }
+      ]
     },
     {
       "name": "reclaimV2",
@@ -1635,7 +1640,12 @@ export const IDL: SerumRemote = {
           "isSigner": false
         }
       ],
-      "args": []
+      "args": [
+        {
+          "name": "additionalData",
+          "type": "bytes"
+        }
+      ]
     },
     {
       "name": "reclaimV2",

--- a/packages/serum-remote/src/serum_remote.ts
+++ b/packages/serum-remote/src/serum_remote.ts
@@ -573,6 +573,11 @@ export type SerumRemote = {
           "name": "depositAccount",
           "isMut": true,
           "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
         }
       ],
       "args": [
@@ -1637,6 +1642,11 @@ export const IDL: SerumRemote = {
         {
           "name": "depositAccount",
           "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
           "isSigner": false
         }
       ],

--- a/packages/serum-remote/src/types.ts
+++ b/packages/serum-remote/src/types.ts
@@ -32,12 +32,9 @@ export type BoundedStrategyV2 = {
   reclaimDate: BN;
   reclaimAddress: web3.PublicKey;
   depositAddress: web3.PublicKey;
-  lookupTable: web3.PublicKey;
   boundedPriceNumerator: BN;
   boundedPriceDenominator: BN;
   bump: number;
-  accountList: web3.PublicKey[];
-  additionalData: number[];
 };
 
 export type BoundedStrategyParams = {

--- a/programs/serum-remote/src/dexes/dex.rs
+++ b/programs/serum-remote/src/dexes/dex.rs
@@ -3,8 +3,6 @@ use std::collections::VecDeque;
 use anchor_lang::prelude::*;
 use enum_dispatch::enum_dispatch;
 
-use crate::instructions::{InitBoundedStrategyV2, ReclaimV2};
-
 #[enum_dispatch]
 pub trait Dex {
     /// Given the amount of tokens_in, return the amount of tokens returned
@@ -38,15 +36,6 @@ pub trait DexStatic<'a, 'info> {
 
     /// Execute the full swap via CPI to the DEX
     fn swap(&self, tokens_in: u64, signers_seeds: &[&[&[u8]]]) -> Result<()>;
-
-    /// Returns the SPL Token account where the assets from the trade are deposited
-    fn destination_token_account(&self) -> AccountInfo<'info>;
-
-    /// Returns the SPL Mint account for the end_mint of a leg
-    fn destination_mint_account(&self) -> AccountInfo<'info>;
-
-    /// Close any accounts and return funds when complete or past execution date
-    fn cleanup_accounts(&self, ctx: &Context<'_, '_, 'a, 'info, ReclaimV2<'info>>) -> Result<()>;
 }
 
 #[derive(Clone, PartialEq)]

--- a/programs/serum-remote/src/dexes/dex.rs
+++ b/programs/serum-remote/src/dexes/dex.rs
@@ -36,12 +36,6 @@ pub trait DexStatic<'a, 'info> {
     where
         Self: Sized;
 
-    /// Handles any initialization needed for the DEX
-    fn initialize(
-        &self,
-        ctx: &Context<'_, '_, '_, 'info, InitBoundedStrategyV2<'info>>,
-    ) -> Result<()>;
-
     /// Execute the full swap via CPI to the DEX
     fn swap(&self, tokens_in: u64, signers_seeds: &[&[&[u8]]]) -> Result<()>;
 

--- a/programs/serum-remote/src/dexes/dex.rs
+++ b/programs/serum-remote/src/dexes/dex.rs
@@ -29,7 +29,6 @@ pub trait DexStatic<'a, 'info> {
     fn from_account_slice(
         accounts: &'a [AccountInfo<'info>],
         additional_data: &mut VecDeque<u8>,
-        is_init: bool,
     ) -> Result<Self>
     where
         Self: Sized;

--- a/programs/serum-remote/src/dexes/dex_list.rs
+++ b/programs/serum-remote/src/dexes/dex_list.rs
@@ -36,17 +36,11 @@ impl DexList {
         }
     }
 
-    pub fn get_end_account_idx(&self, start: usize, is_init: bool) -> usize {
+    pub fn get_end_account_idx(&self, start: usize) -> usize {
         let accounts_len = match self {
             DexList::OpenBookV3 => OpenBookDex::ACCOUNTS_LEN,
             DexList::Raydium => RaydiumSwap::ACCOUNTS_LEN,
         };
-        if is_init {
-            start + accounts_len + 1
-        } else {
-            // TODO: If we remove the Destination Mint from the account list for anything besides
-            //  init, this additional +1 key can be dropped
-            start + accounts_len + 1
-        }
+        start + accounts_len
     }
 }

--- a/programs/serum-remote/src/dexes/leg.rs
+++ b/programs/serum-remote/src/dexes/leg.rs
@@ -18,18 +18,15 @@ impl<'a, 'info> Leg<'a, 'info> {
         dex: DexList,
         account_infos: &'a [AccountInfo<'info>],
         additional_data: &mut VecDeque<u8>,
-        is_init: bool,
     ) -> Result<Self> {
         let res = match dex {
             DexList::OpenBookV3 => Leg::OpenBookV3(OpenBookDex::from_account_slice(
                 account_infos,
                 additional_data,
-                is_init,
             )?),
             DexList::Raydium => Leg::Raydium(RaydiumSwap::from_account_slice(
                 account_infos,
                 additional_data,
-                is_init,
             )?),
         };
 

--- a/programs/serum-remote/src/dexes/leg.rs
+++ b/programs/serum-remote/src/dexes/leg.rs
@@ -3,10 +3,7 @@ use std::collections::VecDeque;
 use anchor_lang::prelude::*;
 use enum_dispatch::enum_dispatch;
 
-use crate::{
-    dexes::Dex,
-    instructions::{InitBoundedStrategyV2, ReclaimV2},
-};
+use crate::dexes::Dex;
 
 use super::{open_book_dex::OpenBookDex, raydium::RaydiumSwap, DexList, DexStatic};
 
@@ -44,30 +41,6 @@ impl<'a, 'info> Leg<'a, 'info> {
         match self {
             Leg::OpenBookV3(open_book_dex) => open_book_dex.swap(tokens_in, signers_seeds),
             Leg::Raydium(raydium_swap) => raydium_swap.swap(tokens_in, signers_seeds),
-        }
-    }
-
-    pub fn destination_token_account(&self) -> AccountInfo<'info> {
-        match self {
-            Leg::OpenBookV3(open_book_dex) => open_book_dex.destination_token_account(),
-            Leg::Raydium(raydium_swap) => raydium_swap.destination_token_account(),
-        }
-    }
-
-    pub fn destination_mint_account(&self) -> AccountInfo<'info> {
-        match self {
-            Leg::OpenBookV3(open_book_dex) => open_book_dex.destination_mint_account(),
-            Leg::Raydium(raydium_swap) => raydium_swap.destination_mint_account(),
-        }
-    }
-
-    pub fn close_dex_accounts(
-        &self,
-        ctx: &Context<'_, '_, 'a, 'info, ReclaimV2<'info>>,
-    ) -> Result<()> {
-        match self {
-            Leg::OpenBookV3(open_book_dex) => open_book_dex.cleanup_accounts(ctx),
-            Leg::Raydium(raydium_swap) => raydium_swap.cleanup_accounts(ctx),
         }
     }
 }

--- a/programs/serum-remote/src/dexes/leg.rs
+++ b/programs/serum-remote/src/dexes/leg.rs
@@ -39,16 +39,6 @@ impl<'a, 'info> Leg<'a, 'info> {
         Ok(res)
     }
 
-    pub fn initialize(
-        &self,
-        ctx: &Context<'_, '_, '_, 'info, InitBoundedStrategyV2<'info>>,
-    ) -> Result<()> {
-        match self {
-            Leg::OpenBookV3(open_book_dex) => open_book_dex.initialize(ctx),
-            Leg::Raydium(raydium_swap) => raydium_swap.initialize(ctx),
-        }
-    }
-
     /// Execute the full swap via CPI to the DEX
     pub fn swap(&self, tokens_in: u64, signers_seeds: &[&[&[u8]]]) -> Result<()> {
         match self {

--- a/programs/serum-remote/src/dexes/open_book_dex.rs
+++ b/programs/serum-remote/src/dexes/open_book_dex.rs
@@ -166,18 +166,12 @@ impl<'a, 'info> DexStatic<'a, 'info> for OpenBookDex<'a, 'info> {
     fn from_account_slice(
         accounts: &'a [AccountInfo<'info>],
         additional_data: &mut VecDeque<u8>,
-        is_init: bool,
     ) -> anchor_lang::Result<OpenBookDex<'a, 'info>> {
         let base_decimals = additional_data.pop_front().unwrap();
         let base_decimals_factor = 10_u64.pow(base_decimals.into());
 
         let base_mint = spl_token_utils::mint(&accounts[7].try_borrow_data()?);
-        // With multi-legs, during initialization this SPL Token account may not exists. So fill with dummy address
-        let destination_mint = if is_init {
-            accounts[16].key()
-        } else {
-            spl_token_utils::mint(&accounts[15].try_borrow_data()?)
-        };
+        let destination_mint = spl_token_utils::mint(&accounts[15].try_borrow_data()?);
         let trade_is_bid = destination_mint == base_mint;
 
         // Load the Serum Market to extract decimal data

--- a/programs/serum-remote/src/dexes/open_book_dex.rs
+++ b/programs/serum-remote/src/dexes/open_book_dex.rs
@@ -267,7 +267,6 @@ impl<'a, 'info> DexStatic<'a, 'info> for OpenBookDex<'a, 'info> {
             spl_token_utils::mint(&accounts[15].try_borrow_data()?)
         };
         let trade_is_bid = destination_mint == base_mint;
-        msg!("trade_is_bid {}", trade_is_bid);
 
         // Load the Serum Market to extract decimal data
         let market = Market::load(&accounts[1], accounts[0].key)
@@ -300,7 +299,6 @@ impl<'a, 'info> DexStatic<'a, 'info> for OpenBookDex<'a, 'info> {
                 market.pc_lot_size,
             )
         };
-        msg!("trade_is_bid {}", trade_is_bid);
 
         let fee_tier = serum_v3::fees::FeeTier::from_srm_and_msrm_balances(accounts[1].key);
         let (fee_numerator, fee_denominator) = fee_tier.taker_rate_fraction();

--- a/programs/serum-remote/src/dexes/open_book_dex.rs
+++ b/programs/serum-remote/src/dexes/open_book_dex.rs
@@ -1,29 +1,23 @@
-use std::{collections::VecDeque, convert::identity, num::NonZeroU64};
+use std::{collections::VecDeque, num::NonZeroU64};
 
-use anchor_lang::{error, prelude::*, solana_program::sysvar};
-use anchor_spl::{
-    dex::{
-        serum_dex::{
-            self,
-            instruction::SelfTradeBehavior,
-            matching::{OrderType, Side},
-            state::{gen_vault_signer_key, Market},
-        },
-        CloseOpenOrders, InitOpenOrders,
+use anchor_lang::{error, prelude::*};
+use anchor_spl::dex::{
+    serum_dex::{
+        self,
+        instruction::SelfTradeBehavior,
+        matching::{OrderType, Side},
+        state::Market,
     },
-    token,
+    CloseOpenOrders,
 };
 use arrayref::array_refs;
-use safe_transmute::transmute_to_bytes;
 
 use crate::{
     constants::{BOUNDED_STRATEGY_SEED, OPEN_ORDERS_SEED},
     dexes::open_book_dex,
     errors::{self, ErrorCode},
-    instructions::{InitBoundedStrategyV2, ReclaimV2},
-    open_orders_seeds, open_orders_signer_seeds,
-    state::BoundedStrategyV2,
-    strategy_signer_seeds,
+    instructions::ReclaimV2,
+    open_orders_seeds, open_orders_signer_seeds, strategy_signer_seeds,
     utils::spl_token_utils,
 };
 
@@ -33,7 +27,6 @@ use super::{
 };
 
 pub const MAX_ORDER_BOOK_DEPTH: usize = 3;
-const OPEN_ORDERS_MEM_SIZE: u64 = 3228;
 
 #[cfg(not(feature = "devnet"))]
 anchor_lang::declare_id!("srmqPvymJeFKQ4zGQed1GFppgkRHL9kaELCbyksJtPX");
@@ -117,24 +110,8 @@ impl<'a, 'info> OpenBookDex<'a, 'info> {
         &self.accounts[8]
     }
 
-    fn vault_signer(&self) -> &AccountInfo<'info> {
-        &self.accounts[9]
-    }
-
     fn rent(&self) -> &AccountInfo<'info> {
         &self.accounts[11]
-    }
-
-    fn expected_vault_signer(&self, market: &Market) -> Pubkey {
-        let res = gen_vault_signer_key(
-            market.vault_signer_nonce,
-            self.serum_market().key,
-            self.dex_program().key,
-        );
-        match res {
-            Ok(key) => key,
-            Err(err) => panic!("market_vault_signer Error: {}", err),
-        }
     }
 
     fn token_program_id(&self) -> &AccountInfo<'info> {
@@ -152,56 +129,6 @@ impl<'a, 'info> OpenBookDex<'a, 'info> {
     // This account at index 16 should only exist during initialization
     fn destination_mint(&self) -> &AccountInfo<'info> {
         &self.accounts[16]
-    }
-
-    fn validate_init(&self, bounded_strategy: &BoundedStrategyV2) -> anchor_lang::Result<()> {
-        let market = Market::load(self.serum_market(), self.dex_program().key)
-            .map_err(|_| errors::ErrorCode::FailedToLoadOpenBookDexMarket)?;
-        // Validate market and mint information
-        let coin_mint = Pubkey::new(&transmute_to_bytes(&identity(market.coin_mint)));
-        let pc_mint = Pubkey::new(&transmute_to_bytes(&identity(market.pc_mint)));
-
-        // TODO: Review this order side. With multi-legs the order side makes no sense. Direction
-        //  of the trade should be determined by the mint addresses of source and destination
-        if self.trade_is_bid && bounded_strategy.collateral_mint != pc_mint {
-            // If Bidding the assets to transfer must the the price currency mint
-            return Err(error!(ErrorCode::BidsRequireQuoteCurrency));
-        } else if !self.trade_is_bid && bounded_strategy.collateral_mint != coin_mint {
-            return Err(error!(ErrorCode::AsksRequireBaseCurrency));
-        }
-
-        ////////////////// Validate the accounts data against the Market //////////////////
-        // These are helpful for user feedback. Downstream programs should validate accounts,
-        //  but validating market information on initialization is nice to have.
-        if self.bids().key.to_bytes() != transmute_to_bytes(&identity(market.bids)) {
-            return Err(error!(ErrorCode::IncorrectKeysForLeg));
-        }
-        if self.asks().key.to_bytes() != transmute_to_bytes(&identity(market.asks)) {
-            return Err(error!(ErrorCode::IncorrectKeysForLeg));
-        }
-        if self.request_queue().key.to_bytes() != transmute_to_bytes(&identity(market.req_q)) {
-            return Err(error!(ErrorCode::IncorrectKeysForLeg));
-        }
-        if self.event_queue().key.to_bytes() != transmute_to_bytes(&identity(market.event_q)) {
-            return Err(error!(ErrorCode::IncorrectKeysForLeg));
-        }
-        if self.coin_vault().key.to_bytes() != transmute_to_bytes(&identity(market.coin_vault)) {
-            return Err(error!(ErrorCode::IncorrectKeysForLeg));
-        }
-        if self.pc_vault().key.to_bytes() != transmute_to_bytes(&identity(market.pc_vault)) {
-            return Err(error!(ErrorCode::IncorrectKeysForLeg));
-        }
-        if self.vault_signer().key != &self.expected_vault_signer(&market) {
-            return Err(error!(ErrorCode::IncorrectKeysForLeg));
-        }
-        if self.token_program_id().key != &token::ID {
-            return Err(error!(ErrorCode::IncorrectKeysForLeg));
-        }
-        if self.rent().key != &sysvar::rent::ID {
-            return Err(error!(ErrorCode::IncorrectKeysForLeg));
-        }
-
-        Ok(())
     }
 }
 
@@ -316,72 +243,6 @@ impl<'a, 'info> DexStatic<'a, 'info> for OpenBookDex<'a, 'info> {
         })
     }
 
-    fn initialize(
-        &self,
-        ctx: &Context<'_, '_, '_, 'info, InitBoundedStrategyV2<'info>>,
-    ) -> anchor_lang::Result<()> {
-        self.validate_init(&ctx.accounts.strategy)?;
-
-        // create OpenOrders account
-        let cpi_accounts = anchor_lang::system_program::CreateAccount {
-            from: ctx.accounts.payer.to_account_info(),
-            to: self.open_orders_account().to_account_info(),
-        };
-        // Get the canonical OpenOrders bump
-        let (open_orders_key, open_orders_bump) = Pubkey::find_program_address(
-            open_orders_seeds!(&ctx.accounts.strategy),
-            ctx.program_id,
-        );
-        if open_orders_key != self.open_orders_account().key() {
-            return Err(error!(ErrorCode::BadOpenOrdersKey));
-        }
-        let cpi_ctx = CpiContext {
-            program: self.dex_program().to_account_info(),
-            accounts: cpi_accounts,
-            remaining_accounts: Vec::new(),
-            signer_seeds: &[open_orders_signer_seeds!(
-                &ctx.accounts.strategy,
-                open_orders_bump
-            )],
-        };
-
-        anchor_lang::system_program::create_account(
-            cpi_ctx,
-            Rent::get()?.minimum_balance(OPEN_ORDERS_MEM_SIZE as usize),
-            OPEN_ORDERS_MEM_SIZE,
-            self.dex_program().key,
-        )?;
-
-        // Initialize the OpenOrders account
-        let init_open_orders_accounts = InitOpenOrders {
-            open_orders: self.open_orders_account().to_account_info(),
-            authority: ctx.accounts.strategy.to_account_info(),
-            market: self.serum_market().to_account_info(),
-            rent: self.rent().to_account_info(),
-        };
-
-        let init_ctx = CpiContext {
-            accounts: init_open_orders_accounts,
-            program: self.dex_program().to_account_info(),
-            remaining_accounts: vec![],
-            signer_seeds: &[strategy_signer_seeds!(&ctx.accounts.strategy)],
-        };
-        let ix = serum_dex::instruction::init_open_orders(
-            &ID,
-            init_ctx.accounts.open_orders.key,
-            init_ctx.accounts.authority.key,
-            init_ctx.accounts.market.key,
-            init_ctx.remaining_accounts.first().map(|acc| acc.key),
-        )
-        .map_err(|pe| ProgramError::from(pe))?;
-        anchor_lang::solana_program::program::invoke_signed(
-            &ix,
-            &ToAccountInfos::to_account_infos(&init_ctx),
-            init_ctx.signer_seeds,
-        )?;
-        Ok(())
-    }
-
     fn swap(&self, amount_in: u64, signers_seeds: &[&[&[u8]]]) -> anchor_lang::Result<()> {
         let (max_pc_qty, max_coin_qty, limit_price, side) = if self.trade_is_bid {
             (
@@ -406,20 +267,20 @@ impl<'a, 'info> DexStatic<'a, 'info> for OpenBookDex<'a, 'info> {
         };
         // Place ioc order
         let new_order_ix = serum_dex::instruction::new_order(
-            self.accounts[1].key,
-            self.accounts[4].key,
-            self.accounts[5].key,
-            self.accounts[6].key,
-            self.accounts[2].key,
-            self.accounts[3].key,
+            self.serum_market().key,
+            self.open_orders_account().key,
+            self.request_queue().key,
+            self.event_queue().key,
+            self.bids().key,
+            self.asks().key,
             self.accounts[14].key,
             self.accounts[13].key,
-            self.accounts[7].key,
-            self.accounts[8].key,
-            self.accounts[10].key,
-            self.accounts[11].key,
+            self.coin_vault().key,
+            self.pc_vault().key,
+            self.token_program_id().key,
+            self.rent().key,
             srm_account_referral,
-            self.accounts[0].key,
+            self.dex_program().key,
             side,
             limit_price,
             max_coin_qty,

--- a/programs/serum-remote/src/dexes/raydium/dex_implementation.rs
+++ b/programs/serum-remote/src/dexes/raydium/dex_implementation.rs
@@ -50,11 +50,6 @@ impl<'a, 'info> RaydiumSwap<'a, 'info> {
     fn user_destination_token_account(&self) -> &AccountInfo<'info> {
         &self.accounts[16]
     }
-
-    // This account at index 19 should only exist during initialization
-    fn destination_mint(&self) -> &AccountInfo<'info> {
-        &self.accounts[19]
-    }
 }
 
 impl Dex for RaydiumSwap<'_, '_> {
@@ -98,14 +93,6 @@ impl Dex for RaydiumSwap<'_, '_> {
 impl<'a, 'info> DexStatic<'a, 'info> for RaydiumSwap<'a, 'info> {
     const ACCOUNTS_LEN: usize = 19;
     const INIT_ACCOUNTS_LEN: usize = 20;
-
-    fn destination_mint_account(&self) -> AccountInfo<'info> {
-        self.destination_mint().to_account_info()
-    }
-
-    fn destination_token_account(&self) -> AccountInfo<'info> {
-        self.user_destination_token_account().to_account_info()
-    }
 
     fn from_account_slice(
         accounts: &'a [AccountInfo<'info>],
@@ -184,13 +171,6 @@ impl<'a, 'info> DexStatic<'a, 'info> for RaydiumSwap<'a, 'info> {
             signers_seeds,
         )
         .unwrap();
-        Ok(())
-    }
-
-    fn cleanup_accounts(
-        &self,
-        _ctx: &Context<'_, '_, 'a, 'info, crate::instructions::ReclaimV2<'info>>,
-    ) -> Result<()> {
         Ok(())
     }
 }

--- a/programs/serum-remote/src/dexes/raydium/dex_implementation.rs
+++ b/programs/serum-remote/src/dexes/raydium/dex_implementation.rs
@@ -97,19 +97,13 @@ impl<'a, 'info> DexStatic<'a, 'info> for RaydiumSwap<'a, 'info> {
     fn from_account_slice(
         accounts: &'a [AccountInfo<'info>],
         _additional_data: &mut std::collections::VecDeque<u8>,
-        is_init: bool,
     ) -> Result<Self>
     where
         Self: Sized,
     {
         let user_source_token_account = &accounts[15];
         let serum_coin_vault_account = &accounts[12];
-        // With multi-legs, during initialization this SPL Token account may not exists. So fill with dummy address
-        let source_mint = if is_init {
-            anchor_lang::system_program::System::id()
-        } else {
-            spl_token_utils::mint(&user_source_token_account.try_borrow_data()?)
-        };
+        let source_mint = spl_token_utils::mint(&user_source_token_account.try_borrow_data()?);
         let base_mint = spl_token_utils::mint(&serum_coin_vault_account.try_borrow_data()?);
         let base_is_input = base_mint == source_mint;
 

--- a/programs/serum-remote/src/dexes/raydium/dex_implementation.rs
+++ b/programs/serum-remote/src/dexes/raydium/dex_implementation.rs
@@ -155,14 +155,6 @@ impl<'a, 'info> DexStatic<'a, 'info> for RaydiumSwap<'a, 'info> {
         })
     }
 
-    fn initialize(
-        &self,
-        _ctx: &Context<'_, '_, '_, 'info, crate::instructions::InitBoundedStrategyV2<'info>>,
-    ) -> Result<()> {
-        // Nothing to initialize for Raydium swapping
-        Ok(())
-    }
-
     fn swap(&self, tokens_in: u64, signers_seeds: &[&[&[u8]]]) -> Result<()> {
         let instruction = swap_base_in(
             self.accounts[0].key,
@@ -197,7 +189,7 @@ impl<'a, 'info> DexStatic<'a, 'info> for RaydiumSwap<'a, 'info> {
 
     fn cleanup_accounts(
         &self,
-        ctx: &Context<'_, '_, 'a, 'info, crate::instructions::ReclaimV2<'info>>,
+        _ctx: &Context<'_, '_, 'a, 'info, crate::instructions::ReclaimV2<'info>>,
     ) -> Result<()> {
         Ok(())
     }

--- a/programs/serum-remote/src/dexes/route.rs
+++ b/programs/serum-remote/src/dexes/route.rs
@@ -14,7 +14,6 @@ impl<'a, 'info> Route<'a, 'info> {
     pub fn create(
         remaining_accounts: &'a [AccountInfo<'info>],
         additional_data: VecDeque<u8>,
-        is_init: bool,
     ) -> Result<Self> {
         // Unpack & initalize the routes from remaining accounts
         let mut route = Route::default();
@@ -22,11 +21,11 @@ impl<'a, 'info> Route<'a, 'info> {
         let mut added_data = additional_data;
         while let Some(dex_program) = remaining_accounts.get(account_cursor) {
             let dex = DexList::from_id(dex_program.key())?;
-            let end_index = dex.get_end_account_idx(account_cursor, is_init);
+            let end_index = dex.get_end_account_idx(account_cursor);
 
             let account_infos = &remaining_accounts[account_cursor..end_index];
             // Create the Leg
-            let leg = Leg::from_account_slice(dex, account_infos, &mut added_data, is_init)?;
+            let leg = Leg::from_account_slice(dex, account_infos, &mut added_data)?;
 
             // Add the leg to the Route
             route.legs[leg_cursor] = Some(leg);

--- a/programs/serum-remote/src/dexes/route.rs
+++ b/programs/serum-remote/src/dexes/route.rs
@@ -1,7 +1,5 @@
 use std::collections::VecDeque;
 
-use crate::instructions::ReclaimV2;
-
 use super::{leg::Leg, math::find_maximum_input, Dex, DexList};
 use anchor_lang::prelude::*;
 
@@ -124,16 +122,6 @@ impl<'a, 'info> Route<'a, 'info> {
             }
         }
         Ok(())
-    }
-
-    ///
-    /// Close and clean up and accounts for each Leg
-    ///
-    pub fn cleanup_accounts(
-        &self,
-        ctx: &Context<'_, '_, 'a, 'info, ReclaimV2<'info>>,
-    ) -> Result<()> {
-        self.for_each_leg(|leg| leg.close_dex_accounts(ctx))
     }
 
     ///

--- a/programs/serum-remote/src/dexes/route.rs
+++ b/programs/serum-remote/src/dexes/route.rs
@@ -265,7 +265,7 @@ impl<'a, 'info> Route<'a, 'info> {
 ///
 /// Check whether the execution price is out of bounds
 ///
-fn is_in_bounds(
+pub fn is_in_bounds(
     input: u64,
     output: u64,
     bounded_price_numerator: &u64,
@@ -275,14 +275,9 @@ fn is_in_bounds(
     //  bound. This must handle the case where output is less than input (i.e. the purchase price is < 1)
     let bounded_numerator = bounded_price_numerator * output;
     let executed_numerator = input * bounded_price_denominator;
-    msg!(
-        "i {} o {} bpn {} bpd {}",
-        input,
-        output,
-        bounded_price_numerator,
-        bounded_price_denominator
-    );
-    if executed_numerator > bounded_numerator {
+    if bounded_numerator == 0 && executed_numerator == 0 {
+        false
+    } else if executed_numerator > bounded_numerator {
         false
     } else {
         true

--- a/programs/serum-remote/src/instructions/bounded_trade_v2.rs
+++ b/programs/serum-remote/src/instructions/bounded_trade_v2.rs
@@ -38,11 +38,17 @@ pub fn handler<'a, 'b, 'c, 'info>(
     ctx: Context<'a, 'b, 'c, 'info, BoundedTradeV2<'info>>,
     additional_data: Vec<u8>,
 ) -> Result<()> {
-    // TODO: Validate that the reclaim date has not passed.
+    let bounded_strategy = &ctx.accounts.strategy;
+
+    // Validate that the reclaim date has not passed.
+    if bounded_strategy.reclaim_date < Clock::get()?.unix_timestamp {
+        return Err(ErrorCode::ReclaimDateHasPassed.into());
+    }
+
+    // store balance data in memory for end of instruction checks
     let starting_input_balance = ctx.accounts.order_payer.amount;
     let starting_destination_balance = ctx.accounts.deposit_account.amount;
 
-    let bounded_strategy = &ctx.accounts.strategy;
     // Build the route
     let route = Route::create(
         ctx.remaining_accounts,

--- a/programs/serum-remote/src/instructions/bounded_trade_v2.rs
+++ b/programs/serum-remote/src/instructions/bounded_trade_v2.rs
@@ -53,7 +53,6 @@ pub fn handler<'a, 'b, 'c, 'info>(
     let route = Route::create(
         ctx.remaining_accounts,
         VecDeque::from(additional_data.to_vec()),
-        false,
     )?;
     // Validate that the route starts and ends with the right tokens
     if ctx.accounts.order_payer.mint != route.start_mint()? {

--- a/programs/serum-remote/src/instructions/reclaim_v2.rs
+++ b/programs/serum-remote/src/instructions/reclaim_v2.rs
@@ -1,10 +1,8 @@
-use std::collections::VecDeque;
-
 use anchor_lang::prelude::*;
 use anchor_spl::token::{self, CloseAccount, Token, TokenAccount, Transfer};
 
 use crate::{
-    constants::BOUNDED_STRATEGY_SEED, dexes::Route, errors::ErrorCode, state::BoundedStrategyV2,
+    constants::BOUNDED_STRATEGY_SEED, errors::ErrorCode, state::BoundedStrategyV2,
     strategy_signer_seeds,
 };
 
@@ -42,12 +40,6 @@ pub fn handler<'info>(ctx: Context<'_, '_, '_, 'info, ReclaimV2<'info>>) -> Resu
         return Err(ErrorCode::ReclaimDateHasNotPassed.into());
     }
 
-    let route = Route::create(
-        ctx.remaining_accounts,
-        VecDeque::from(bounded_strategy.additional_data.to_vec()),
-        false,
-    )?;
-
     let cpi_accounts = Transfer {
         from: ctx.accounts.collateral_account.to_account_info(),
         to: ctx.accounts.reclaim_account.to_account_info(),
@@ -74,7 +66,5 @@ pub fn handler<'info>(ctx: Context<'_, '_, '_, 'info, ReclaimV2<'info>>) -> Resu
         signer_seeds: &[strategy_signer_seeds!(bounded_strategy)],
         remaining_accounts: Vec::new(),
     };
-    token::close_account(cpi_ctx)?;
-
-    route.cleanup_accounts(&ctx)
+    token::close_account(cpi_ctx)
 }

--- a/programs/serum-remote/src/lib.rs
+++ b/programs/serum-remote/src/lib.rs
@@ -70,7 +70,6 @@ pub mod serum_remote {
         bounded_price_numerator: u64,
         bounded_price_denominator: u64,
         reclaim_date: i64,
-        additional_data: Vec<u8>,
     ) -> Result<()> {
         instructions::init_bounded_strategy_v2::handler(
             ctx,
@@ -78,7 +77,6 @@ pub mod serum_remote {
             bounded_price_numerator,
             bounded_price_denominator,
             reclaim_date,
-            additional_data,
         )
     }
 

--- a/programs/serum-remote/src/lib.rs
+++ b/programs/serum-remote/src/lib.rs
@@ -82,8 +82,9 @@ pub mod serum_remote {
 
     pub fn bounded_trade_v2<'a, 'b, 'c, 'info>(
         ctx: Context<'a, 'b, 'c, 'info, BoundedTradeV2<'info>>,
+        additional_data: Vec<u8>,
     ) -> Result<()> {
-        instructions::bounded_trade_v2::handler(ctx)
+        instructions::bounded_trade_v2::handler(ctx, additional_data)
     }
 
     pub fn reclaim_v2<'info>(ctx: Context<'_, '_, '_, 'info, ReclaimV2<'info>>) -> Result<()> {

--- a/programs/serum-remote/src/state/bounded_strategy_v2.rs
+++ b/programs/serum-remote/src/state/bounded_strategy_v2.rs
@@ -26,17 +26,9 @@ pub struct BoundedStrategyV2 {
     pub bounded_price_denominator: u64,
     /// The bump for the strategy's derived address
     pub bump: u8,
-    /// The address of the look up table. This needs to be stored on-chain for keeping clients
-    /// in sync
-    pub lookup_table: Pubkey,
-    // A slice that holds the list of account addresses for the route
-    // TODO: Extend this to 40+ keys
-    pub account_list: [Pubkey; MAX_ACCOUNTS],
-    /// A slice that holds additional data for DEXes in the route
-    pub additional_data: [u8; 32],
 }
 
 impl BoundedStrategyV2 {
     pub const LEN: usize = 8 + std::mem::size_of::<BoundedStrategyV2>() + 320;
 }
-const_assert!(BoundedStrategyV2::LEN == 1576);
+const_assert!(BoundedStrategyV2::LEN == 488);

--- a/tests/boundedTradeV2.ts
+++ b/tests/boundedTradeV2.ts
@@ -20,6 +20,7 @@ import {
 } from "./utils";
 import OpenBookDex from "../packages/serum-remote/src/dexes/openBookDex";
 import { WRAPPED_SOL_MINT } from "@project-serum/serum/lib/token-instructions";
+import { TOKEN_PROGRAM_ID } from "@solana/spl-token";
 
 /**
  * SerumMarket is in the current state Bids and Asks
@@ -257,6 +258,7 @@ describe("BoundedTradeV2", () => {
               strategy: boundedStrategyKey,
               orderPayer: boundedStrategy.collateralAccount,
               depositAccount: boundedStrategy.depositAddress,
+              tokenProgram: TOKEN_PROGRAM_ID,
             })
             .remainingAccounts(remainingAccounts)
             .instruction();
@@ -333,6 +335,7 @@ describe("BoundedTradeV2", () => {
               strategy: boundedStrategyKey,
               orderPayer: boundedStrategy.collateralAccount,
               depositAccount: boundedStrategy.depositAddress,
+              tokenProgram: TOKEN_PROGRAM_ID,
             })
             .remainingAccounts(remainingAccounts)
             .instruction();
@@ -393,6 +396,7 @@ describe("BoundedTradeV2", () => {
               strategy: boundedStrategyKey,
               orderPayer: boundedStrategy.collateralAccount,
               depositAccount: boundedStrategy.depositAddress,
+              tokenProgram: TOKEN_PROGRAM_ID,
             })
             .remainingAccounts(remainingAccounts)
             .instruction();
@@ -450,6 +454,7 @@ describe("BoundedTradeV2", () => {
               strategy: boundedStrategyKey,
               orderPayer: boundedStrategy.collateralAccount,
               depositAccount: boundedStrategy.depositAddress,
+              tokenProgram: TOKEN_PROGRAM_ID,
             })
             .remainingAccounts(remainingAccounts)
             .instruction();

--- a/tests/boundedTradeV2.ts
+++ b/tests/boundedTradeV2.ts
@@ -157,10 +157,6 @@ describe("BoundedTradeV2", () => {
         depositAddress,
         destinationMint
       );
-      const additionalData = new BN(
-        // @ts-ignore
-        serumMarket._baseSplTokenDecimals
-      ).toArrayLike(Buffer, "le", 1);
       const lookupTableAddress = await createLookUpTable(
         program.provider,
         initAdditionalAccounts
@@ -171,21 +167,18 @@ describe("BoundedTradeV2", () => {
           transferAmount,
           boundedPriceNumerator,
           boundedPriceDenominator,
-          reclaimDate,
-          additionalData
+          reclaimDate
         )
         .accounts({
           payer: program.provider.publicKey,
           collateralAccount,
           mint: collateralMint,
-          lookupTable: lookupTableAddress,
           strategy: boundedStrategyKey,
           reclaimAccount: reclaimAddress,
           depositAccount: depositAddress,
           tokenProgram: SPL_TOKEN_PROGRAM_ID,
           systemProgram: web3.SystemProgram.programId,
         })
-        .remainingAccounts(initAdditionalAccounts)
         .instruction();
       await compileAndSendV0Tx(
         program.provider,

--- a/tests/boundedTradeV2.ts
+++ b/tests/boundedTradeV2.ts
@@ -111,6 +111,16 @@ describe("BoundedTradeV2", () => {
       baseTransferAmount.muln(10).toNumber()
     );
     const transaction = new web3.Transaction();
+    // Create OpenOrders account for the user
+    openOrdersKeypair = new web3.Keypair();
+    const createOpenOrdersIx = await OpenOrders.makeCreateAccountTransaction(
+      program.provider.connection,
+      serumMarket.address,
+      payerKey,
+      openOrdersKeypair.publicKey,
+      serumMarket.programId
+    );
+    transaction.add(createOpenOrdersIx);
 
     const mintToInstruction = await tokenProgram.methods
       .mintTo(quoteTransferAmount.muln(10))
@@ -136,7 +146,7 @@ describe("BoundedTradeV2", () => {
       })
       .instruction();
     transaction.add(syncNativeIx);
-    await program.provider.sendAndConfirm(transaction);
+    await program.provider.sendAndConfirm(transaction, [openOrdersKeypair]);
 
     initBoundedStrategy = async (
       nonce: number,
@@ -224,19 +234,6 @@ describe("BoundedTradeV2", () => {
             WRAPPED_SOL_MINT,
             quoteTransferAmount
           ));
-          // Create OpenOrders account for the user
-          const transaction = new web3.Transaction();
-          openOrdersKeypair = new web3.Keypair();
-          const createOpenOrdersIx =
-            await OpenOrders.makeCreateAccountTransaction(
-              program.provider.connection,
-              serumMarket.address,
-              payerKey,
-              openOrdersKeypair.publicKey,
-              serumMarket.programId
-            );
-          transaction.add(createOpenOrdersIx);
-          program.provider.sendAndConfirm(transaction, [openOrdersKeypair]);
           boundedStrategy = await program.account.boundedStrategyV2.fetch(
             boundedStrategyKey
           );
@@ -250,7 +247,7 @@ describe("BoundedTradeV2", () => {
             boundedStrategy.depositAddress,
             WRAPPED_SOL_MINT,
             openOrdersKeypair.publicKey,
-            boundedStrategyKey
+            payerKey
           );
           // Create and send the BoundedTradeV2 transaction
           const ix = await program.methods
@@ -316,19 +313,6 @@ describe("BoundedTradeV2", () => {
             WRAPPED_SOL_MINT,
             quoteTransferAmount
           ));
-          // Create OpenOrders account for the user
-          const transaction = new web3.Transaction();
-          openOrdersKeypair = new web3.Keypair();
-          const createOpenOrdersIx =
-            await OpenOrders.makeCreateAccountTransaction(
-              program.provider.connection,
-              serumMarket.address,
-              payerKey,
-              openOrdersKeypair.publicKey,
-              serumMarket.programId
-            );
-          transaction.add(createOpenOrdersIx);
-          program.provider.sendAndConfirm(transaction, [openOrdersKeypair]);
           boundedStrategy = await program.account.boundedStrategyV2.fetch(
             boundedStrategyKey
           );
@@ -340,7 +324,7 @@ describe("BoundedTradeV2", () => {
             boundedStrategy.depositAddress,
             WRAPPED_SOL_MINT,
             openOrdersKeypair.publicKey,
-            boundedStrategyKey
+            payerKey
           );
           const ix = await program.methods
             .boundedTradeV2(additionalData)
@@ -389,19 +373,6 @@ describe("BoundedTradeV2", () => {
             USDC_MINT,
             baseTransferAmount
           ));
-          // Create OpenOrders account for the user
-          const transaction = new web3.Transaction();
-          openOrdersKeypair = new web3.Keypair();
-          const createOpenOrdersIx =
-            await OpenOrders.makeCreateAccountTransaction(
-              program.provider.connection,
-              serumMarket.address,
-              payerKey,
-              openOrdersKeypair.publicKey,
-              serumMarket.programId
-            );
-          transaction.add(createOpenOrdersIx);
-          program.provider.sendAndConfirm(transaction, [openOrdersKeypair]);
           boundedStrategy = await program.account.boundedStrategyV2.fetch(
             boundedStrategyKey
           );
@@ -413,7 +384,7 @@ describe("BoundedTradeV2", () => {
             boundedStrategy.depositAddress,
             USDC_MINT,
             openOrdersKeypair.publicKey,
-            boundedStrategyKey
+            payerKey
           );
           const ix = await program.methods
             .boundedTradeV2(additionalData)
@@ -455,19 +426,6 @@ describe("BoundedTradeV2", () => {
             USDC_MINT,
             baseTransferAmount
           ));
-          // Create OpenOrders account for the user
-          const transaction = new web3.Transaction();
-          openOrdersKeypair = new web3.Keypair();
-          const createOpenOrdersIx =
-            await OpenOrders.makeCreateAccountTransaction(
-              program.provider.connection,
-              serumMarket.address,
-              payerKey,
-              openOrdersKeypair.publicKey,
-              serumMarket.programId
-            );
-          transaction.add(createOpenOrdersIx);
-          program.provider.sendAndConfirm(transaction, [openOrdersKeypair]);
           boundedStrategy = await program.account.boundedStrategyV2.fetch(
             boundedStrategyKey
           );
@@ -482,7 +440,7 @@ describe("BoundedTradeV2", () => {
             boundedStrategy.depositAddress,
             USDC_MINT,
             openOrdersKeypair.publicKey,
-            boundedStrategyKey
+            payerKey
           );
 
           const ix = await program.methods

--- a/tests/boundedTradeV2.ts
+++ b/tests/boundedTradeV2.ts
@@ -168,17 +168,18 @@ describe("BoundedTradeV2", () => {
           boundPriceDenominator: boundedPriceDenominator,
           reclaimDate,
         });
-      const initAdditionalAccounts = await OpenBookDex.initLegAccounts(
-        program.programId,
+
+      const remainingAccounts = await OpenBookDex.tradeAccounts(
         serumMarket,
-        boundedStrategyKey,
         collateralAccount,
         depositAddress,
-        destinationMint
+        openOrdersKeypair.publicKey,
+        payerKey
       );
+
       lookupTableAddress = await createLookUpTable(
         program.provider,
-        initAdditionalAccounts
+        remainingAccounts
       );
 
       const instruction = await program.methods
@@ -246,7 +247,6 @@ describe("BoundedTradeV2", () => {
             serumMarket,
             boundedStrategy.collateralAccount,
             boundedStrategy.depositAddress,
-            WRAPPED_SOL_MINT,
             openOrdersKeypair.publicKey,
             payerKey
           );
@@ -324,7 +324,6 @@ describe("BoundedTradeV2", () => {
             serumMarket,
             boundedStrategy.collateralAccount,
             boundedStrategy.depositAddress,
-            WRAPPED_SOL_MINT,
             openOrdersKeypair.publicKey,
             payerKey
           );
@@ -385,7 +384,6 @@ describe("BoundedTradeV2", () => {
             serumMarket,
             boundedStrategy.collateralAccount,
             boundedStrategy.depositAddress,
-            USDC_MINT,
             openOrdersKeypair.publicKey,
             payerKey
           );
@@ -442,7 +440,6 @@ describe("BoundedTradeV2", () => {
             serumMarket,
             boundedStrategy.collateralAccount,
             boundedStrategy.depositAddress,
-            USDC_MINT,
             openOrdersKeypair.publicKey,
             payerKey
           );

--- a/tests/multiLeggedTrade.ts
+++ b/tests/multiLeggedTrade.ts
@@ -230,10 +230,7 @@ describe("OpenBook + Raydium Trade", () => {
         transferAmount,
         boundPriceNumerator,
         boundPriceDenominator,
-        reclaimDate,
-        orderSide,
-        bound,
-        additionalData
+        reclaimDate
       )
       .accounts({
         payer: program.provider.publicKey,
@@ -242,10 +239,8 @@ describe("OpenBook + Raydium Trade", () => {
         strategy: boundedStrategyKey,
         reclaimAccount: reclaimAddress,
         depositAccount: depositAddress,
-        lookupTable: lookupTableAddress,
         tokenProgram: SPL_TOKEN_PROGRAM_ID,
         systemProgram: web3.SystemProgram.programId,
-        rent: web3.SYSVAR_RENT_PUBKEY,
       })
       .remainingAccounts(remainingAccounts)
       .instruction();

--- a/tests/multiLeggedTrade.ts
+++ b/tests/multiLeggedTrade.ts
@@ -45,6 +45,7 @@ describe("OpenBook + Raydium Trade", () => {
   let serumMarket: Market;
   let coinMint: web3.PublicKey, coinUsdcSerumMarket: Market;
   let boundedStrategyKey: web3.PublicKey, collateralAccount: web3.PublicKey;
+  let additionalData: Buffer;
 
   before(async () => {
     serumMarket = await Market.load(
@@ -53,6 +54,10 @@ describe("OpenBook + Raydium Trade", () => {
       {},
       OPEN_BOOK_DEX_ID
     );
+    additionalData = new BN(
+      // @ts-ignore
+      serumMarket._baseSplTokenDecimals
+    ).toArrayLike(Buffer, "le", 1);
     await program.provider.connection.requestAirdrop(
       payerKey,
       10_000_000_000_000
@@ -379,7 +384,7 @@ describe("OpenBook + Raydium Trade", () => {
       ];
       // Create and send the BoundedTradeV2 transaction
       const ix = await program.methods
-        .boundedTradeV2()
+        .boundedTradeV2(additionalData)
         .accounts({
           payer: program.provider.publicKey,
           strategy: boundedStrategyKey,

--- a/tests/multiLeggedTrade.ts
+++ b/tests/multiLeggedTrade.ts
@@ -334,7 +334,6 @@ describe("OpenBook + Raydium Trade", () => {
         collateralAccount,
         // Because this is a multi-leg route, with a following leg, the Trade Destination Account is an intermediary token account
         traderUsdcKey,
-        USDC_MINT,
         traderOpenOrdersKeypair.publicKey,
         traderKeypair.publicKey
       );
@@ -348,8 +347,7 @@ describe("OpenBook + Raydium Trade", () => {
         traderUsdcKey,
         traderKeypair.publicKey,
         // Because this is the last leg, the Trade Destination Account is the deposit address
-        depositAddress,
-        coinMint
+        depositAddress
       );
       const remainingAccounts = [
         ...openBookRemainingAccounts,

--- a/tests/reclaimV2.ts
+++ b/tests/reclaimV2.ts
@@ -37,9 +37,7 @@ describe("ReclaimV2", () => {
   let quoteTransferAmount = new BN(10_000_000);
   let baseTransferAmount = new BN(10_000_000_000);
   let boundedStrategy: BoundedStrategyV2;
-  let boundedStrategyKey: web3.PublicKey,
-    collateralAddress: web3.PublicKey,
-    openOrdersKey: web3.PublicKey;
+  let boundedStrategyKey: web3.PublicKey, collateralAddress: web3.PublicKey;
 
   const initBoundStrat = async (_reclaimDate: BN) => {
     const {
@@ -52,18 +50,6 @@ describe("ReclaimV2", () => {
     });
     boundedStrategyKey = _boundedStrategyKey;
     collateralAddress = _collateralAccount;
-    const initAdditionalAccounts = await OpenBookDex.initLegAccounts(
-      program.programId,
-      serumMarket,
-      boundedStrategyKey,
-      collateralAddress,
-      depositAddress,
-      WRAPPED_SOL_MINT
-    );
-    const lookupTableAddress = await createLookUpTable(
-      program.provider,
-      initAdditionalAccounts
-    );
     const ix = await program.methods
       .initBoundedStrategyV2(
         transferAmount,
@@ -81,18 +67,13 @@ describe("ReclaimV2", () => {
         tokenProgram: SPL_TOKEN_PROGRAM_ID,
         systemProgram: web3.SystemProgram.programId,
       })
-      .remainingAccounts(initAdditionalAccounts)
       .instruction();
-    await compileAndSendV0Tx(
-      program.provider,
-      payerKeypair,
-      lookupTableAddress,
-      [ix],
-      (err) => {
-        console.error(err);
-      }
-    );
-    openOrdersKey = initAdditionalAccounts[4].pubkey;
+    try {
+      const tx = new web3.Transaction().add(ix);
+      await program.provider.sendAndConfirm(tx);
+    } catch (err) {
+      console.error(err);
+    }
     boundedStrategy = await program.account.boundedStrategyV2.fetch(
       boundedStrategyKey
     );
@@ -191,19 +172,12 @@ describe("ReclaimV2", () => {
     });
 
     it("should return assets", async () => {
-      const [reclaimAccountBefore, collateralAccountBefore, remainingAccounts] =
-        await Promise.all([
+      const [reclaimAccountBefore, collateralAccountBefore] = await Promise.all(
+        [
           tokenProgram.account.account.fetch(reclaimAddress),
           tokenProgram.account.account.fetch(collateralAddress),
-          OpenBookDex.reclaimAccounts(
-            program.programId,
-            serumMarket,
-            boundedStrategyKey,
-            boundedStrategy.collateralAccount,
-            boundedStrategy.depositAddress,
-            WRAPPED_SOL_MINT
-          ),
-        ]);
+        ]
+      );
       try {
         await program.methods
           .reclaimV2()
@@ -214,24 +188,18 @@ describe("ReclaimV2", () => {
             reclaimAccount: reclaimAddress,
             tokenProgram: TOKEN_PROGRAM_ID,
           })
-          .remainingAccounts(remainingAccounts)
           .rpc();
       } catch (err) {
         console.log(err);
         assert.ok(false);
       }
 
-      const [
-        reclaimAccountAfter,
-        collateralAccountAfter,
-        boundedStrategyInfo,
-        openOrdersInfo,
-      ] = await Promise.all([
-        tokenProgram.account.account.fetch(reclaimAddress),
-        program.provider.connection.getAccountInfo(collateralAddress),
-        program.provider.connection.getAccountInfo(boundedStrategyKey),
-        program.provider.connection.getAccountInfo(openOrdersKey),
-      ]);
+      const [reclaimAccountAfter, collateralAccountAfter, boundedStrategyInfo] =
+        await Promise.all([
+          tokenProgram.account.account.fetch(reclaimAddress),
+          program.provider.connection.getAccountInfo(collateralAddress),
+          program.provider.connection.getAccountInfo(boundedStrategyKey),
+        ]);
       const reclaimDiff = reclaimAccountAfter.amount.sub(
         reclaimAccountBefore.amount
       );
@@ -241,7 +209,6 @@ describe("ReclaimV2", () => {
       );
       assert.ok(!collateralAccountAfter);
       assert.ok(!boundedStrategyInfo);
-      assert.ok(!openOrdersInfo);
     });
 
     it("should error on wrong receiver/reclaim address", async () => {

--- a/tests/reclaimV2.ts
+++ b/tests/reclaimV2.ts
@@ -60,10 +60,6 @@ describe("ReclaimV2", () => {
       depositAddress,
       WRAPPED_SOL_MINT
     );
-    const additionalData = new BN(
-      // @ts-ignore
-      serumMarket._baseSplTokenDecimals
-    ).toArrayLike(Buffer, "le", 1);
     const lookupTableAddress = await createLookUpTable(
       program.provider,
       initAdditionalAccounts
@@ -73,15 +69,13 @@ describe("ReclaimV2", () => {
         transferAmount,
         boundPriceNumerator,
         boundPriceDenominator,
-        _reclaimDate,
-        additionalData
+        _reclaimDate
       )
       .accounts({
         payer: program.provider.publicKey,
         collateralAccount: collateralAddress,
         mint: USDC_MINT,
         strategy: boundedStrategyKey,
-        lookupTable: lookupTableAddress,
         reclaimAccount: reclaimAddress,
         depositAccount: depositAddress,
         tokenProgram: SPL_TOKEN_PROGRAM_ID,


### PR DESCRIPTION
* Refactor init_strategy_v2 to have no knowledge of the Route
* bounded_trade_v2 delegates an appropriate amount tokens to the trader for the duration of the instructions
* reclaim_v2 has 0 need to clean up.
* Remove unnecessary fields from `BoundedStrategyV2`
* Remove unnecessary destination_mint from being passed into legs

All initialization and clean up for trades is offloaded to the trader executing the strategy, making the program much more evergreen